### PR TITLE
Add github stats, and technologies you use

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ JonBergland/JonBergland is a ✨ special ✨ repository because its `README.md` 
 You can click the Preview link to take a look at your changes.
 --->
 
+## Technologies & Tools I use:
+<div align="center">
+      <img src="https://www.vectorlogo.zone/logos/java/java-icon.svg" alt="java"           width="75" height="75"/> 
+      <img src="https://www.vectorlogo.zone/logos/python/python-icon.svg" alt="python"     width="65 height="65"/>
+</div>
 
 ---
 ### <img src='https://media1.giphy.com/media/du3J3cXyzhj75IOgvA/giphy.gif?cid=ecf05e47x2g034i9pzwtzzsd3xgg2w9nr94t4tflbbgo3008&rid=giphy.gif' width='25' /> My Github Stats:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jon Bergland
 - 👋 Hi, I’m Jon Bergland
-- 👨‍🎓 I'm currently doing a Bachellor in Computer Engineering
+- 👨‍🎓 I'm currently doing a Bachellor in Computer Engineering at NTNU
 - 🌱 I’m currently learning Java
 - 📫 How to reach me ...
 

--- a/README.md
+++ b/README.md
@@ -8,3 +8,24 @@
 JonBergland/JonBergland is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 You can click the Preview link to take a look at your changes.
 --->
+
+
+---
+### <img src='https://media1.giphy.com/media/du3J3cXyzhj75IOgvA/giphy.gif?cid=ecf05e47x2g034i9pzwtzzsd3xgg2w9nr94t4tflbbgo3008&rid=giphy.gif' width='25' /> My Github Stats:
+<div align="center"></img>
+  <a href="https://github.com/JonBergland#gh-dark-mode-only"></img>
+    <div>
+      <img height="160em" src="https://github-readme-stats.vercel.app/api?username=JonBergland&show_icons=true&border_color=414868&theme=tokyonight"/>&nbsp;
+      <img height="160em" src="https://github-readme-stats.vercel.app/api/top-langs/?username=JonBergland&layout=compact&border_color=414868&theme=tokyonight"/>&nbsp;
+    </div>
+  </a>
+  <a href="https://github.com/JonBergland#gh-light-mode-only"></img>
+    <div>
+      <img height="160em" src="https://github-readme-stats.vercel.app/api?username=JonBergland&show_icons=true"/>&nbsp;
+      <img height="160em" src="https://github-readme-stats.vercel.app/api/top-langs/?username=JonBergland&layout=compact"/>&nbsp;
+    </div>
+  </a>
+</div>
+
+
+****


### PR DESCRIPTION
This adds two new sections: The live github stats of all your public repositories, both for darkmode and lightmode. and it adds the technologies you work with as SVG icons